### PR TITLE
chore: 🤖 added node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+node_modules


### PR DESCRIPTION
### The what
added node_modules to gitignore

### The why
it's not necessary to keep track of node_modules as running ```yarn install``` recreates it automatically

### Uncertainties
First time doing this, usually happens automatically so it's kinda weird